### PR TITLE
fix: app resource 탐색을 context classloader 기준으로 수정

### DIFF
--- a/src/main/java/froggy/winterframework/boot/WinterApplication.java
+++ b/src/main/java/froggy/winterframework/boot/WinterApplication.java
@@ -213,8 +213,8 @@ public class WinterApplication {
     private Set<Class<?>> scanAutoConfigClasses() {
         Set<Class<?>> autoConfigClasses = new HashSet<>();
         try {
-            Enumeration<URL> configFiles = ClassLoader
-                .getSystemResources("META-INF/winter.autoconfig");
+            Enumeration<URL> configFiles = Thread.currentThread().getContextClassLoader()
+                .getResources("META-INF/winter.autoconfig");
             while (configFiles.hasMoreElements()) {
                 URL resource = configFiles.nextElement();
                 for (String className : readClassName(resource)) {

--- a/src/main/java/froggy/winterframework/core/env/Environment.java
+++ b/src/main/java/froggy/winterframework/core/env/Environment.java
@@ -119,7 +119,7 @@ public class Environment {
     public class PropertyLoader {
         private PropertySource load() throws IOException {
             Properties prop = new Properties();
-            try (InputStream input = ClassLoader.getSystemClassLoader()
+            try (InputStream input = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("application.properties")) {
                 if (input == null) {
                     return new PropertySource("properties", new HashMap<>());


### PR DESCRIPTION
이번 변경은 application.properties와 META-INF/winter.autoconfig 탐색 기준을 current thread context classloader로 맞춘다.

mvn exec:java처럼 Maven이 app을 대신 실행하는 경우에는 app resource가 system classloader가 아니라 context classloader 쪽에 잡힌다. 기존 system classloader 기준 탐색은 이런 실행 방식에서 app resource를 찾지 못할 수 있었다.

설정 파일 로딩과 auto-config 파일 탐색을 같은 기준으로 맞춰, 실행 방식이 달라도 app resource를 같은 기준으로 찾도록 한다.

Closes #20
